### PR TITLE
Add support for sqldelight dialects (e.g. mysql)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,10 +32,10 @@ jobs:
         key: caches-${{ runner.os }}
     - name: Setup bazelisk for Bazel builds
       uses: holvonix-open/setup-bazelisk@v0.6.1
-    - name: Build All
-      run: bazel build //...
-    - name: Test All
-      run: bazel test //...
+    - name: Build Wrapper
+      run: bazel build //actions/...
+    - name: Test Wrapper and Rules
+      run: bazel test //actions/... //:sqldelight_tests
     - name: Extract Rules Release Package (for testing)
       run: |
         bazel build //:rules_sqldelight_release

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,7 +43,13 @@ jobs:
         mkdir -p ${{ env.RELEASE_REPO }}
         tar -xzvf bazel-bin/rules_sqldelight_release.tgz -C ${{ env.RELEASE_REPO }}
         ls -l ${{ env.RELEASE_REPO }}
-    - name: Test Sample
+    - name: "Test Sample: Trivial"
       run: |
-        cd samples/trivial
+        pushd samples/trivial
         bazel build --override_repository=rules_sqldelight=${{ env.RELEASE_REPO }} //...
+        popd
+    - name: "Test Sample: Dialect"
+      run: |
+        pushd samples/dialect
+        bazel build --override_repository=rules_sqldelight=${{ env.RELEASE_REPO }} //...
+        popd

--- a/actions/java/com/squareup/tools/sqldelight/cli/Args.kt
+++ b/actions/java/com/squareup/tools/sqldelight/cli/Args.kt
@@ -1,18 +1,22 @@
 package com.squareup.tools.sqldelight.cli
 
+import com.alecstrong.sql.psi.core.DialectPreset
+import com.alecstrong.sql.psi.core.DialectPreset.SQLITE_3_18
 import com.xenomachina.argparser.ArgParser
+import com.xenomachina.argparser.SystemExitException
 import com.xenomachina.argparser.default
 import java.io.File
+import java.util.Locale
 
 class Args(parser: ArgParser) {
   val srcJar by parser.storing(
     "--output_srcjar", "-o",
-    help = "Srcjar of generated code."
+    help = "Path to generated sources jar"
   ) { File(this) }
 
   val srcDirs by parser.adding(
     "--src_dir",
-    help = "Directories containing all srcs"
+    help = "Directory containing SQL source files"
   ) { File(this) }
 
   val packageName by parser.storing(
@@ -22,13 +26,28 @@ class Args(parser: ArgParser) {
 
   val moduleName by parser.storing(
     "--module_name",
-    help = "Module Name for Kotlin compilation (not required for legacy)"
+    help = "Module Name for Kotlin compilation"
   )
 
   val databaseName by parser.storing(
     "--database_name",
     help = "Database Name for Kotlin compilation (not required for legacy). Default as `Database`."
   ).default("Database")
+
+  val dialect by parser.storing(
+    "--database_dialect",
+    argName = "DIALECT",
+    help = "One of the supported SQL dialects: ${DialectPreset.values().joinToString(", ")}"
+  ) {
+    try {
+      DialectPreset.valueOf(this.toUpperCase(Locale.ROOT))
+    } catch (e: IllegalArgumentException) {
+      throw SystemExitException(
+        "Invalid dialect. Should be one of: ${DialectPreset.values().joinToString(", ")}",
+        2
+      )
+    }
+  }.default(SQLITE_3_18)
 
   val fileNames by parser.positionalList(help = "<list of SQL files to process>")
 }

--- a/actions/java/com/squareup/tools/sqldelight/cli/Args.kt
+++ b/actions/java/com/squareup/tools/sqldelight/cli/Args.kt
@@ -43,7 +43,7 @@ class Args(parser: ArgParser) {
       DialectPreset.valueOf(this.toUpperCase(Locale.ROOT))
     } catch (e: IllegalArgumentException) {
       throw SystemExitException(
-        "Invalid dialect. Should be one of: ${DialectPreset.values().joinToString(", ")}",
+        "Invalid dialect \"$this\". Should be one of: ${DialectPreset.values().joinToString(", ")}",
         2
       )
     }

--- a/actions/java/com/squareup/tools/sqldelight/cli/CompilerWrapper.kt
+++ b/actions/java/com/squareup/tools/sqldelight/cli/CompilerWrapper.kt
@@ -1,5 +1,6 @@
 package com.squareup.tools.sqldelight.cli
 
+import com.alecstrong.sql.psi.core.DialectPreset
 import com.squareup.sqldelight.core.SqlDelightDatabaseProperties
 import com.squareup.sqldelight.core.SqlDelightEnvironment
 import java.io.File
@@ -12,7 +13,8 @@ class CompilerWrapper(
   packageName: String,
   private val outputDirectory: File,
   private val moduleName: String,
-  databaseName: String
+  databaseName: String,
+  databaseDialect: DialectPreset
 ) {
   private val logger = Logger.getLogger(CompilerWrapper::class.java.name)
   private val defaultProperties = SqlDelightDatabaseProperties(
@@ -20,6 +22,7 @@ class CompilerWrapper(
     compilationUnits = emptyList(),
     outputDirectory = outputDirectory.toString(),
     className = databaseName,
+    dialectPreset = databaseDialect,
     dependencies = emptyList()
   )
 

--- a/actions/java/com/squareup/tools/sqldelight/cli/Main.kt
+++ b/actions/java/com/squareup/tools/sqldelight/cli/Main.kt
@@ -9,13 +9,19 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
 fun main(rawArgs: Array<String>) = mainBody {
+  realMain(rawArgs)
+}
+
+/** Extracted to allow testing without xenomachina [mainBody] auto-handling errors */
+internal fun realMain(rawArgs: Array<String>) {
   val args = ArgParser(rawArgs).parseInto(::Args)
   val tmpOut = Files.createTempDirectory("sqldelight")
   val files = CompilerWrapper(
           args.packageName,
           tmpOut.toFile(),
           args.moduleName,
-          args.databaseName)
+          args.databaseName,
+          args.dialect)
     .generate(args.srcDirs)
 
   val srcJar = args.srcJar.toPath()

--- a/actions/java/com/squareup/tools/sqldelight/cli/Main.kt
+++ b/actions/java/com/squareup/tools/sqldelight/cli/Main.kt
@@ -1,13 +1,14 @@
 package com.squareup.tools.sqldelight.cli
 
 import com.xenomachina.argparser.ArgParser
+import com.xenomachina.argparser.mainBody
 import java.io.BufferedOutputStream
 import java.nio.file.Files
 import java.nio.file.StandardOpenOption
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
-fun main(rawArgs: Array<String>) {
+fun main(rawArgs: Array<String>) = mainBody {
   val args = ArgParser(rawArgs).parseInto(::Args)
   val tmpOut = Files.createTempDirectory("sqldelight")
   val files = CompilerWrapper(

--- a/actions/javatests/com/squareup/tools/sqldelight/cli/ArgsTest.kt
+++ b/actions/javatests/com/squareup/tools/sqldelight/cli/ArgsTest.kt
@@ -1,0 +1,25 @@
+package com.squareup.tools.sqldelight.cli
+
+import com.xenomachina.argparser.ShowHelpException
+import com.xenomachina.argparser.SystemExitException
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class ArgsTest {
+  @Test
+  fun help() {
+    val args = arrayOf("--help")
+    assertThrows(ShowHelpException::class.java) {
+      realMain(args)
+    }
+  }
+
+  @Test
+  fun badDialect() {
+    val args = arrayOf("--database_dialect=FOOSQL")
+    val e = assertThrows(SystemExitException::class.java) {
+      realMain(args)
+    }
+    assert(e.message!!.contains("Invalid dialect \"FOOSQL\". Should be one of: SQLITE_3_18"))
+  }
+}

--- a/actions/javatests/com/squareup/tools/sqldelight/cli/BUILD.bazel
+++ b/actions/javatests/com/squareup/tools/sqldelight/cli/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+
+kt_jvm_test(
+    name = "ArgsTest",
+    srcs = ["ArgsTest.kt"],
+    friends = ["//actions/java/com/squareup/tools/sqldelight/cli"],
+    deps = [
+        "@maven_sqldelight//com/xenomachina:kotlin-argparser",
+        "@maven_sqldelight//junit",
+    ],
+)

--- a/samples/dialect/BUILD.bazel
+++ b/samples/dialect/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@rules_sqldelight//:sqldelight.bzl", "sqldelight_codegen")
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "define_kt_toolchain", "kt_jvm_library")
+
+kt_jvm_library(
+    name = "library",
+    srcs = glob(["src/main/java/**/*.java"]) + [":generated_sources"],
+    deps = [
+        "@maven//com/squareup/sqldelight:jdbc-driver",
+    ],
+)
+
+sqldelight_codegen(
+    name = "generated_sources",
+    package_name = "sqldelight.bazel.rules.samples",
+    srcs = ["src/main/sqldelight/sqldelight/bazel/rules/samples/oneFourZero.sq"],
+    database_dialect = "MYSQL",
+    src_dir = "src/main/sqldelight",
+)
+
+define_kt_toolchain(
+    name = "kotlin_toolchain",
+    api_version = "1.4",
+    jvm_target = "1.8",  # proguard demands.
+    language_version = "1.4",
+)

--- a/samples/dialect/README.md
+++ b/samples/dialect/README.md
@@ -1,0 +1,26 @@
+# Sample: Dialect
+
+An example project which uses the sqldelight rules.
+
+This sample shows using SQLDelight against MySql (though any dialect
+supported by SQLDelight should work.
+
+This example will fail, if not run against the release binary package.
+The repository presently points at ../.. but this project doesn't contain
+all the source-level dependencies needed to use the rules project directly.
+Instead, run the following:
+
+```sh
+cd <root project workspace>
+bazel build //:rules_sqldelight_release
+mkdir /tmp/sqldelight_repo
+tar -xzf bazel-bin/rules_sqldelight_release.tgz -C /tmp/sqldelight_repo
+cd samples/dialect
+bazel build --override-repository=rules_sqldelight=/tmp/sqldelight_repo
+```
+
+This will build the rules, and execute this trivial example against the packaged rules.
+
+This logic is applied in the CI actions.
+
+> TODO (cgruber): Set up a convenience script to run the samples.

--- a/samples/dialect/WORKSPACE
+++ b/samples/dialect/WORKSPACE
@@ -1,0 +1,79 @@
+workspace(name = "sqldelight_rules_sample")
+
+SQLDELIGHT_VERSION = "1.4.0"
+
+KOTLIN_VERSION = "1.4.32"
+
+KOTLINC_RELEASE_SHA = "dfef23bb86bd5f36166d4ec1267c8de53b3827c446d54e82322c6b6daad3594c"
+
+KOTLINC_RELEASE_URL = "https://github.com/JetBrains/kotlin/releases/download/v{v}/kotlin-compiler-{v}.zip".format(v = KOTLIN_VERSION)
+
+MAVEN_REPOSITORY_RULES_VERSION = "2.0.0-alpha-4"
+
+MAVEN_REPOSITORY_RULES_SHA = "a6484fec8d1aebd4affff7ae1ee9b59141858b2c636222bdb619526ccd8b3358"
+
+RULES_KOTLIN_VERSION = "1.5.0-alpha-3"
+
+RULES_KOTLIN_SHA = "eeae65f973b70896e474c57aa7681e444d7a5446d9ec0a59bb88c59fc263ff62"
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+maybe(
+    http_archive,
+    name = "io_bazel_rules_kotlin",
+    sha256 = RULES_KOTLIN_SHA,
+    url = "https://github.com/bazelbuild/rules_kotlin/releases/download/v%s/rules_kotlin_release.tgz" % RULES_KOTLIN_VERSION,
+)
+
+maybe(
+    http_archive,
+    name = "maven_repository_rules",
+    sha256 = MAVEN_REPOSITORY_RULES_SHA,
+    strip_prefix = "bazel_maven_repository-%s" % MAVEN_REPOSITORY_RULES_VERSION,
+    type = "zip",
+    url = "https://github.com/square/bazel_maven_repository/archive/%s.zip" % MAVEN_REPOSITORY_RULES_VERSION,
+)
+
+maybe(
+    http_archive,
+    name = "build_bazel_rules_android",
+    sha256 = "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
+    strip_prefix = "rules_android-0.1.1",
+    url = "https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip",
+)
+
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
+
+kotlin_repositories(compiler_release = {
+    "urls": [KOTLINC_RELEASE_URL],
+    "sha256": KOTLINC_RELEASE_SHA,
+})
+
+register_toolchains("//:kotlin_toolchain")
+
+load("@maven_repository_rules//maven:maven.bzl", "maven_repository_specification")
+
+maven_repository_specification(
+    name = "maven",
+    artifacts = {
+        "com.squareup.sqldelight:jdbc-driver:%s" % SQLDELIGHT_VERSION: {"insecure": True},
+        "com.squareup.sqldelight:runtime-jvm:%s" % SQLDELIGHT_VERSION: {"insecure": True},
+        "org.jetbrains:annotations:13.0": {"insecure": True},
+        "org.jetbrains.kotlin:kotlin-stdlib:%s" % KOTLIN_VERSION: {"insecure": True},
+        "org.jetbrains.kotlin:kotlin-stdlib-common:%s" % KOTLIN_VERSION: {"insecure": True},
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk7:%s" % KOTLIN_VERSION: {"insecure": True},
+    },
+)
+
+android_sdk_repository(
+    name = "androidsdk",
+    api_level = 29,
+    build_tools_version = "29.0.3",
+)
+
+# Will break - use --override_repository=/path/to/exploded/release/artifact
+local_repository(
+    name = "rules_sqldelight",
+    path = "../..",
+)

--- a/samples/dialect/src/main/java/sqldelight/bazel/rules/samples/VariableAttribute.java
+++ b/samples/dialect/src/main/java/sqldelight/bazel/rules/samples/VariableAttribute.java
@@ -1,0 +1,5 @@
+package sqldelight.bazel.rules.samples;
+
+public class VariableAttribute {
+
+}

--- a/samples/dialect/src/main/sqldelight/sqldelight/bazel/rules/samples/oneFourZero.sq
+++ b/samples/dialect/src/main/sqldelight/sqldelight/bazel/rules/samples/oneFourZero.sq
@@ -1,0 +1,26 @@
+import sqldelight.bazel.rules.samples.VariableAttribute;
+import kotlin.collections.Map;
+
+CREATE TABLE experiments (
+  experimentName TEXT NOT NULL PRIMARY KEY,
+  variantName TEXT,
+  featureVariables TEXT AS Map<String, VariableAttribute> NOT NULL,
+  isActive INTEGER AS Boolean DEFAULT 0 NOT NULL
+);
+
+insertExperiment:
+INSERT OR REPLACE INTO experiments (
+experimentName,
+variantName,
+featureVariables,
+isActive
+)
+VALUES (?, ?, ?, ?);
+
+retrieveExperiments:
+SELECT *
+FROM experiments;
+
+clearExperiments:
+DELETE
+FROM experiments;

--- a/samples/dialect/tools/bazel
+++ b/samples/dialect/tools/bazel
@@ -1,0 +1,1 @@
+../../../scripts/bazel.sample.wrapper.sh

--- a/samples/trivial/BUILD.bazel
+++ b/samples/trivial/BUILD.bazel
@@ -2,8 +2,8 @@ load("@rules_sqldelight//:sqldelight.bzl", "sqldelight_codegen")
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "define_kt_toolchain", "kt_android_library")
 
 kt_android_library(
-    name = "r1_4_0",
-    srcs = glob(["src/main/java/**/*.java"]) + [":r1_4_0_sqldelight"],
+    name = "library",
+    srcs = glob(["src/main/java/**/*.java"]) + [":generated_sources"],
     deps = [
         "@maven_sqldelight//androidx/sqlite",
         "@maven_sqldelight//androidx/sqlite:sqlite-ktx",
@@ -13,10 +13,10 @@ kt_android_library(
 )
 
 sqldelight_codegen(
-    name = "r1_4_0_sqldelight",
-    package_name = "sqldelight.bazel.samples.r1_4_0",
+    name = "generated_sources",
+    package_name = "sqldelight.bazel.rules.samples",
     srcs = ["src/main/sqldelight/sqldelight/bazel/rules/samples/oneFourZero.sq"],
-    src_dir = "sqldelight",
+    src_dir = "src/main/sqldelight",
 )
 
 define_kt_toolchain(

--- a/samples/trivial/tools/bazel
+++ b/samples/trivial/tools/bazel
@@ -1,0 +1,1 @@
+../../../scripts/bazel.sample.wrapper.sh

--- a/scripts/bazel.sample.wrapper.sh
+++ b/scripts/bazel.sample.wrapper.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Split the args into bazel specific and run-specific
+bazel_args=()
+runner_args=()
+while (( $# > 0 )) ; do
+  case "$1" in
+    "--")
+      runner_args+=( "--" )
+      ;;
+    *)
+      if (( "${#runner_args[*]}" > 0 )) ; then
+        runner_args+=( "$1" )
+      else
+        bazel_args+=( "$1" )
+      fi
+      ;;
+  esac
+  shift
+done
+
+for arg in ${bazel_args[*]} ; do
+  if [[ "$arg" == --override_repository=rules_sqldelight* ]] ; then
+    overriden_repository=true
+    break
+  fi
+done
+
+if [[ "${overriden_repository}" != true ]] ; then
+  root="$(dirname "$(dirname "$(dirname "$(dirname "$0")")")")"
+  binary_pkg="${root}/bazel-bin/rules_sqldelight_release.tgz"
+  if [[ ! -f "${binary_pkg}" ]] ; then
+    echo -n "Please either build the //:sqldelight_release_pkg in ${root} or otherwise run "
+    echo "bazel with --override_repository pointing to an un-tarred release package."
+    exit 1
+  fi
+  rules_dir=$(mktemp -d -t ci-XXXXXX)
+  trap 'rm -rf "${rules_dir}"' EXIT
+
+  echo "Expanding ${binary_pkg} to ${rules_dir}"
+  tar -xzf "${binary_pkg}" -C "${rules_dir}"
+  bazel_args+=("--override_repository=rules_sqldelight=${rules_dir}")
+
+fi
+
+# shellcheck disable=SC2086
+# We want word splitting here.
+"${BAZEL_REAL}" ${bazel_args[*]} ${runner_args[*]}

--- a/scripts/maven.bzl
+++ b/scripts/maven.bzl
@@ -25,9 +25,9 @@ def register_action_deps():
         artifacts = {
             "com.xenomachina:kotlin-argparser:2.0.7": {"insecure": True},
             "com.xenomachina:xenocom:0.0.7": {"insecure": True},
-            "com.beust:jcommander:1.78": {"insecure": True},
             "com.squareup.sqldelight:core:%s" % SQLDELIGHT_VERSION: {"insecure": True},
             "org.antlr:antlr4-runtime:4.5.3": {"insecure": True},
+            "junit:junit:4.13": {"insecure": True, "testonly": True, "exclude": ["org.hamcrest:hamcrest-core"]},
 
             # Transitive
             "androidx.annotation:annotation:1.1.0": {"insecure": True},

--- a/sqldelight.bzl
+++ b/sqldelight.bzl
@@ -44,6 +44,8 @@ def _sqldelight_codegen_impl(ctx):
     args.add("--module_name", "\"%s\"" % module_name)
     if ctx.attr.database_name:
         args.add("--database_name", ctx.attr.database_name)
+    if ctx.attr.database_dialect:
+        args.add("--database_dialect", ctx.attr.database_dialect)
     src_roots = {}
     if not len(ctx.files.srcs):
         fail("No sources found. Must specify one or more .sq files to process.")
@@ -94,6 +96,7 @@ sqldelight_codegen = rule(
         "module_name": attr.string(),
         "package_name": attr.string(),
         "database_name": attr.string(),
+        "database_dialect": attr.string(),
     },
     output_to_genfiles = True,
     outputs = {


### PR DESCRIPTION
This PR does a few things.
  * Adds support for `database_dialect = "MYSQL"` (or any other type supported by SQLDelight)
  * Improves error messages for this.
  * Fixes an issue with args-parsing when bad args happen (wasn't wrapped with the error-handling wrapper, so exceptions were leaking to the CLI)
  * Adds a few tests in the kotlin code
  * Adds a little bazel wrapper for the sample projects, to allow them to "just run" (without extracting stuff) as long as the parent project has built the release binary