### PR TITLE
Fix license formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ sqldelight_codegen(
 
 ## License
 
-``
+```
 # Copyright (C) 2020 Square, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -106,7 +106,7 @@ sqldelight_codegen(
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
-``
+```
 
 For full license terms, see [LICENSE](LICENSE) for details.
 


### PR DESCRIPTION
The lines of the license was appearing as headings because the surrounding code fence was two backticks instead of three